### PR TITLE
Use `parking_lot` instead of mapped lock guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "scooter"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1063,6 +1063,7 @@ dependencies = [
  "ignore",
  "itertools",
  "log",
+ "parking_lot",
  "rand",
  "ratatui",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scooter"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["thomasschafer97@gmail.com"]
 license = "MIT"
@@ -22,6 +22,7 @@ futures = "0.3.31"
 ignore = "0.4.22"
 itertools = "0.13.0"
 log = "0.4.22"
+parking_lot = "0.12.3"
 ratatui = "0.27.0"
 regex = "1.10.6"
 serde = { version = "1.0.204", features = ["derive"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly" # Allows us to use MappedLockGuard

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(mapped_lock_guards)]
-
 pub mod app;
 pub mod event;
 pub mod fields;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(mapped_lock_guards)]
-
 use clap::Parser;
 use event::EventHandlingResult;
 use log::LevelFilter;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -44,7 +44,7 @@ fn render_search_view(frame: &mut Frame<'_>, app: &App, rect: Rect) {
         .zip(areas)
         .enumerate()
         .for_each(|(idx, (SearchField { name, field }, field_area))| {
-            field.read().unwrap().render(
+            field.read().render(
                 frame,
                 field_area,
                 name.title().to_owned(),
@@ -53,13 +53,7 @@ fn render_search_view(frame: &mut Frame<'_>, app: &App, rect: Rect) {
         });
 
     let highlighted_area = areas[app.search_fields.highlighted];
-    if let Some(cursor_idx) = app
-        .search_fields
-        .highlighted_field()
-        .read()
-        .unwrap()
-        .cursor_idx()
-    {
+    if let Some(cursor_idx) = app.search_fields.highlighted_field().read().cursor_idx() {
         frame.set_cursor(
             highlighted_area.x + cursor_idx as u16 + 1,
             highlighted_area.y + 1,
@@ -233,9 +227,7 @@ fn render_confirmation_view(frame: &mut Frame<'_>, app: &App, rect: Rect) {
     frame.render_widget(List::new(search_results), list_area);
 }
 
-fn render_results_view(
-    replace_state: &ReplaceState,
-) -> impl Fn(&mut Frame<'_>, &App, Rect) + use<'_> {
+fn render_results_view(replace_state: &ReplaceState) -> impl Fn(&mut Frame<'_>, &App, Rect) + '_ {
     move |frame: &mut Frame<'_>, _app: &App, rect: Rect| {
         let [area] = Layout::horizontal([Constraint::Percentage(80)])
             .flex(Flex::Center)

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -154,7 +154,7 @@ fn collect_files(dir: &Path, base: &Path, files: &mut Vec<String>) {
                 .to_str()
                 .unwrap()
                 .to_string()
-                .replace("\\", "/");
+                .replace('\\', "/");
             files.push(rel_path);
         } else if path.is_dir() {
             collect_files(&path, base, files);

--- a/tests/fields.rs
+++ b/tests/fields.rs
@@ -1,9 +1,10 @@
+use parking_lot::RwLock;
 use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 use scooter::{
     parsed_fields::SearchType, CheckboxField, Field, FieldName, SearchField, SearchFields,
     TextField,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[test]
 fn test_text_field_operations() {
@@ -115,7 +116,6 @@ fn test_search_fields() {
         search_fields
             .highlighted_field()
             .write()
-            .unwrap()
             .handle_keys(KeyCode::Char(c), KeyModifiers::NONE);
     }
     assert_eq!(search_fields.search().text, "test search");
@@ -126,7 +126,6 @@ fn test_search_fields() {
         search_fields
             .highlighted_field()
             .write()
-            .unwrap()
             .handle_keys(KeyCode::Char(c), KeyModifiers::NONE);
     }
     assert_eq!(search_fields.replace().text, "test replace");
@@ -136,7 +135,6 @@ fn test_search_fields() {
     search_fields
         .highlighted_field()
         .write()
-        .unwrap()
         .handle_keys(KeyCode::Char(' '), KeyModifiers::NONE);
     assert!(search_fields.fixed_strings().checked);
 
@@ -149,7 +147,6 @@ fn test_search_fields() {
     search_fields
         .highlighted_field()
         .write()
-        .unwrap()
         .handle_keys(KeyCode::Char(' '), KeyModifiers::NONE);
     let search_type = search_fields.search_type().unwrap();
     match search_type {


### PR DESCRIPTION
This allows us to not require the use of nightly Rust, fixing issues with installation e.g. in Brew