### PR TITLE
Add flag to use additional regex features (e.g. negative lookahead)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,5 @@ jobs:
     - name: Lint
       run: cargo clippy
 
-    - name: Run tests (Windows)
-      if: matrix.os == 'windows-latest'
-      run: cargo test --verbose -- --test-threads=1
-
-    - name: Run tests (Unix)
-      if: matrix.os != 'windows-latest'
+    - name: Run tests
       run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +417,17 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1042,6 +1068,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "etcetera",
+ "fancy-regex",
  "futures",
  "ignore",
  "itertools",
@@ -1471,7 +1498,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scooter"
 version = "0.2.1"
 dependencies = [
@@ -1079,6 +1088,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serial_test",
  "similar",
  "simple-log",
  "tempfile",
@@ -1090,6 +1100,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
 
 [[package]]
 name = "serde"
@@ -1144,6 +1160,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ content_inspector = "0.2.4"
 crossterm = { version = "0.27", features = ["event-stream"] }
 dirs = "5.0.1"
 etcetera = "0.8.0"
+fancy-regex = "0.14.0"
 futures = "0.3.31"
 ignore = "0.4.23"
 itertools = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ratatui = "0.27.0"
 regex = "1.11.1"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
+serial_test = "3.2.0"
 similar = "2.6.0"
 simple-log = "2.1.1"
 tokio = { version = "1.41.1", features = ["full"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,7 +183,7 @@ pub struct SearchFields {
     pub fields: [SearchField; NUM_SEARCH_FIELDS],
     pub highlighted: usize,
     pub show_error_popup: bool,
-    pub advanced_regex: bool,
+    advanced_regex: bool,
 }
 
 macro_rules! define_field_accessor {
@@ -270,6 +270,11 @@ impl SearchFields {
         }
     }
 
+    pub fn with_advanced_regex(mut self, advanced_regex: bool) -> Self {
+        self.advanced_regex = advanced_regex;
+        self
+    }
+
     fn highlighted_field_impl(&self) -> &SearchField {
         &self.fields[self.highlighted]
     }
@@ -326,11 +331,10 @@ enum ValidatedField<T> {
 pub struct App {
     pub current_screen: Screen,
     pub search_fields: SearchFields,
-    pub directory: PathBuf,
-    pub include_hidden: bool,
+    directory: PathBuf,
+    include_hidden: bool,
 
-    pub running: bool,
-    pub app_event_sender: UnboundedSender<AppEvent>,
+    app_event_sender: UnboundedSender<AppEvent>,
 }
 
 const BINARY_EXTENSIONS: &[&str] = &["png", "gif", "jpg", "jpeg", "ico", "svg", "pdf"];
@@ -346,8 +350,8 @@ impl App {
             Some(d) => d,
             None => std::env::current_dir().unwrap(),
         };
-        let mut search_fields = SearchFields::with_values("", "", false, "");
-        search_fields.advanced_regex = advanced_regex;
+        let search_fields =
+            SearchFields::with_values("", "", false, "").with_advanced_regex(advanced_regex);
 
         Self {
             current_screen: Screen::SearchFields,
@@ -355,7 +359,6 @@ impl App {
             directory,
             include_hidden,
 
-            running: true,
             app_event_sender,
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -119,9 +119,9 @@ impl ReplaceState {
 pub struct SearchInProgressState {
     pub search_state: SearchState,
     pub last_render: Instant,
-    pub handle: JoinHandle<()>,
-    pub processing_sender: UnboundedSender<BackgroundProcessingEvent>,
-    pub processing_receiver: UnboundedReceiver<BackgroundProcessingEvent>,
+    handle: JoinHandle<()>,
+    processing_sender: UnboundedSender<BackgroundProcessingEvent>,
+    processing_receiver: UnboundedReceiver<BackgroundProcessingEvent>,
 }
 
 impl SearchInProgressState {
@@ -153,7 +153,7 @@ pub enum Screen {
 }
 
 impl Screen {
-    pub fn search_results_mut(&mut self) -> &mut SearchState {
+    fn search_results_mut(&mut self) -> &mut SearchState {
         match self {
             Screen::SearchProgressing(SearchInProgressState { search_state, .. }) => search_state,
             Screen::SearchComplete(search_state) => search_state,

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -7,7 +7,7 @@ use ratatui::{
     Frame,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FieldError {
     pub short: String,
     pub long: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
     tui.init()?;
     tui.draw(&mut app)?;
 
-    while app.running {
+    loop {
         let EventHandlingResult { exit, rerender } = tokio::select! {
             Some(event) = tui.events.receiver.recv() => {
                 match event {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ struct Args {
         default_value = DEFAULT_LOG_LEVEL
     )]
     log_level: LevelFilter,
+
+    /// Use advanced regex features (including negative look-ahead), at the cost of performance
+    #[arg(short = 'a', long, default_value = "false")]
+    advanced_regex: bool,
 }
 
 fn parse_log_level(s: &str) -> Result<LevelFilter, String> {
@@ -52,8 +56,6 @@ async fn main() -> anyhow::Result<()> {
 
     setup_logging(args.log_level)?;
 
-    let args = Args::parse();
-
     let directory = match args.directory {
         None => None,
         Some(d) => Some(validate_directory(&d)?),
@@ -61,7 +63,12 @@ async fn main() -> anyhow::Result<()> {
 
     let app_events_handler = EventHandler::new();
     let app_event_sender = app_events_handler.app_event_sender.clone();
-    let mut app = App::new(directory, args.hidden, app_event_sender);
+    let mut app = App::new(
+        directory,
+        args.hidden,
+        args.advanced_regex,
+        app_event_sender,
+    );
 
     let backend = CrosstermBackend::new(io::stdout());
     let terminal = Terminal::new(backend)?;

--- a/src/parsed_fields.rs
+++ b/src/parsed_fields.rs
@@ -1,4 +1,5 @@
 use content_inspector::{inspect, ContentType};
+use fancy_regex::Regex as FancyRegex;
 use ignore::{WalkBuilder, WalkParallel};
 use log::warn;
 use regex::Regex;
@@ -17,6 +18,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub enum SearchType {
     Pattern(Regex),
+    PatternAdvanced(FancyRegex),
     Fixed(String),
 }
 
@@ -111,6 +113,13 @@ impl ParsedFields {
             }
             SearchType::Pattern(ref p) => {
                 if p.is_match(&line) {
+                    Some(p.replace_all(&line, &self.replace_string).to_string())
+                } else {
+                    None
+                }
+            }
+            SearchType::PatternAdvanced(ref p) => {
+                if p.is_match(&line).unwrap() {
                     Some(p.replace_all(&line, &self.replace_string).to_string())
                 } else {
                     None

--- a/src/parsed_fields.rs
+++ b/src/parsed_fields.rs
@@ -126,10 +126,10 @@ impl ParsedFields {
                 }
             }
             SearchType::PatternAdvanced(ref p) => {
-                if p.is_match(&line).unwrap() {
-                    Some(p.replace_all(&line, &self.replace_string).to_string())
-                } else {
-                    None
+                // TODO: try catch
+                match p.is_match(&line) {
+                    Ok(true) => Some(p.replace_all(&line, &self.replace_string).to_string()),
+                    _ => None,
                 }
             }
         };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Flex, Layout, Rect},
     style::{Color, Style, Stylize},
     text::{Line, Span, Text},
-    widgets::{Block, Clear, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Clear, List, ListItem, Paragraph},
     Frame,
 };
 use similar::{Change, ChangeTag, TextDiff};
@@ -64,7 +64,7 @@ fn render_search_view(frame: &mut Frame<'_>, app: &App, rect: Rect) {
                     .lines()
                     .map(|line| {
                         Line::from(vec![Span::styled(
-                            format!("  {line}"),
+                            line.to_string(),
                             Style::default().fg(Color::Red),
                         )])
                     })
@@ -85,13 +85,11 @@ fn render_search_view(frame: &mut Frame<'_>, app: &App, rect: Rect) {
             Constraint::Length(content_height),
         );
 
-        let popup = Paragraph::new(error_lines)
-            .block(
-                Block::bordered()
-                    .title("Errors")
-                    .title_alignment(Alignment::Center),
-            )
-            .wrap(Wrap { trim: true });
+        let popup = Paragraph::new(error_lines).block(
+            Block::bordered()
+                .title("Errors")
+                .title_alignment(Alignment::Center),
+        );
         frame.render_widget(Clear, popup_area);
         frame.render_widget(popup, popup_area);
     } else if let Some(cursor_idx) = app.search_fields.highlighted_field().read().cursor_idx() {

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -349,247 +349,284 @@ async fn search_and_replace_test(
     }
 }
 
-#[tokio::test]
-async fn test_perform_search_fixed_string() {
-    let temp_dir = create_test_files! {
-        "file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for testing",
-        },
-        "file3.txt" => {
-            "something",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "something",
-        }
-    };
+macro_rules! test_with_both_regex_modes {
+    ($name:ident, $test_fn:expr) => {
+        mod $name {
+            use super::*;
 
-    search_and_replace_test(
-        &temp_dir,
-        SearchFields::with_values(".*", "example", true, ""),
-        false,
-        vec![
-            (Path::new("file1.txt"), 0),
-            (Path::new("file2.txt"), 0),
-            (Path::new("file3.txt"), 1),
-        ],
-    )
-    .await;
+            #[tokio::test]
+            async fn with_advanced_regex() {
+                ($test_fn)(true).await;
+            }
 
-    assert_test_files! {
-        &temp_dir,
-        "file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for testing",
-        },
-        "file3.txt" => {
-            "something",
-            "123 bar[a-b]+examplebar)(baz 456",
-            "something",
+            #[tokio::test]
+            async fn without_advanced_regex() {
+                ($test_fn)(false).await;
+            }
         }
     };
 }
 
-#[tokio::test]
-async fn test_update_search_results_regex() {
-    let temp_dir = &create_test_files! {
-        "file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for testing",
-        },
-        "file3.txt" => {
-            "something",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "something",
-        }
-    };
+test_with_both_regex_modes!(
+    test_perform_search_fixed_string,
+    |advanced_regex: bool| async move {
+        let temp_dir = create_test_files! {
+            "file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for testing",
+            },
+            "file3.txt" => {
+                "something",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "something",
+            }
+        };
 
-    search_and_replace_test(
-        temp_dir,
-        SearchFields::with_values(r"\b\w+ing\b", "VERB", false, ""),
-        false,
-        vec![
-            (Path::new("file1.txt"), 1),
-            (Path::new("file2.txt"), 1),
-            (Path::new("file3.txt"), 2),
-        ],
-    )
-    .await;
+        let search_fields = SearchFields::with_values(".*", "example", true, "")
+            .with_advanced_regex(advanced_regex);
+        search_and_replace_test(
+            &temp_dir,
+            search_fields,
+            false,
+            vec![
+                (Path::new("file1.txt"), 0),
+                (Path::new("file2.txt"), 0),
+                (Path::new("file3.txt"), 1),
+            ],
+        )
+        .await;
 
-    assert_test_files! {
-        temp_dir,
-        "file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For VERB purposes",
-        },
-        "file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for VERB",
-        },
-        "file3.txt" => {
-            "VERB",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "VERB",
-        }
-    };
-}
+        assert_test_files! {
+            &temp_dir,
+            "file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for testing",
+            },
+            "file3.txt" => {
+                "something",
+                "123 bar[a-b]+examplebar)(baz 456",
+                "something",
+            }
+        };
+    }
+);
 
-#[tokio::test]
-async fn test_update_search_results_no_matches() {
-    let temp_dir = &create_test_files! {
-        "file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for testing",
-        },
-        "file3.txt" => {
-            "something",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "something",
-        }
-    };
+test_with_both_regex_modes!(
+    test_update_search_results_regex,
+    |advanced_regex: bool| async move {
+        let temp_dir = &create_test_files! {
+            "file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for testing",
+            },
+            "file3.txt" => {
+                "something",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "something",
+            }
+        };
 
-    search_and_replace_test(
-        temp_dir,
-        SearchFields::with_values(r"nonexistent-string", "replacement", true, ""),
-        false,
-        vec![
-            (Path::new("file1.txt"), 0),
-            (Path::new("file2.txt"), 0),
-            (Path::new("file3.txt"), 0),
-        ],
-    )
-    .await;
+        let search_fields = SearchFields::with_values(r"\b\w+ing\b", "VERB", false, "")
+            .with_advanced_regex(advanced_regex);
+        search_and_replace_test(
+            temp_dir,
+            search_fields,
+            false,
+            vec![
+                (Path::new("file1.txt"), 1),
+                (Path::new("file2.txt"), 1),
+                (Path::new("file3.txt"), 2),
+            ],
+        )
+        .await;
 
-    assert_test_files! {
-        temp_dir,
-        "file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for testing",
-        },
-        "file3.txt" => {
-            "something",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "something",
-        }
-    };
-}
+        assert_test_files! {
+            temp_dir,
+            "file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For VERB purposes",
+            },
+            "file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for VERB",
+            },
+            "file3.txt" => {
+                "VERB",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "VERB",
+            }
+        };
+    }
+);
 
-#[tokio::test]
-async fn test_update_search_results_invalid_regex() {
-    let temp_dir = &create_test_files! {
-        "file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for testing",
-        },
-        "file3.txt" => {
-            "something",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "something",
-        }
-    };
+test_with_both_regex_modes!(
+    test_update_search_results_no_matches,
+    |advanced_regex: bool| async move {
+        let temp_dir = &create_test_files! {
+            "file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for testing",
+            },
+            "file3.txt" => {
+                "something",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "something",
+            }
+        };
 
-    let search_fields = SearchFields::with_values(r"[invalid regex", "replacement", false, "");
-    let mut app = setup_app(temp_dir, search_fields, false);
+        let search_fields =
+            SearchFields::with_values(r"nonexistent-string", "replacement", true, "")
+                .with_advanced_regex(advanced_regex);
+        search_and_replace_test(
+            temp_dir,
+            search_fields,
+            false,
+            vec![
+                (Path::new("file1.txt"), 0),
+                (Path::new("file2.txt"), 0),
+                (Path::new("file3.txt"), 0),
+            ],
+        )
+        .await;
 
-    let res = app.perform_search_if_valid();
-    assert!(!res.exit);
-    assert!(matches!(app.current_screen, Screen::SearchFields));
-    process_bp_events(&mut app).await;
-    assert!(!wait_for_screen!(&app, Screen::SearchComplete)); // We shouldn't get to the SearchComplete page, so assert that we never get there
-    assert!(matches!(app.current_screen, Screen::SearchFields));
-}
+        assert_test_files! {
+            temp_dir,
+            "file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for testing",
+            },
+            "file3.txt" => {
+                "something",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "something",
+            }
+        };
+    }
+);
 
-#[tokio::test]
-async fn test_update_search_results_filtered_dir() {
-    let temp_dir = &create_test_files! {
-        "dir1/file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "dir2/file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for testing",
-        },
-        "dir2/file3.txt" => {
-            "something",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "something testing",
-        }
-    };
+test_with_both_regex_modes!(
+    test_update_search_results_invalid_regex,
+    |advanced_regex: bool| async move {
+        let temp_dir = &create_test_files! {
+            "file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for testing",
+            },
+            "file3.txt" => {
+                "something",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "something",
+            }
+        };
 
-    search_and_replace_test(
-        temp_dir,
-        SearchFields::with_values(r"testing", "f", false, "dir2"),
-        false,
-        vec![
-            (&Path::new("dir1").join("file1.txt"), 0),
-            (&Path::new("dir2").join("file2.txt"), 1),
-            (&Path::new("dir2").join("file3.txt"), 1),
-        ],
-    )
-    .await;
+        let search_fields = SearchFields::with_values(r"[invalid regex", "replacement", false, "")
+            .with_advanced_regex(advanced_regex);
+        let mut app = setup_app(temp_dir, search_fields, false);
 
-    assert_test_files! {
-        temp_dir,
-        "dir1/file1.txt" => {
-            "This is a test file",
-            "It contains some test content",
-            "For testing purposes",
-        },
-        "dir2/file2.txt" => {
-            "Another test file",
-            "With different content",
-            "Also for f",
-        },
-        "dir2/file3.txt" => {
-            "something",
-            "123 bar[a-b]+.*bar)(baz 456",
-            "something f",
-        }
-    };
-}
+        let res = app.perform_search_if_valid();
+        assert!(!res.exit);
+        assert!(matches!(app.current_screen, Screen::SearchFields));
+        process_bp_events(&mut app).await;
+        assert!(!wait_for_screen!(&app, Screen::SearchComplete)); // We shouldn't get to the SearchComplete page, so assert that we never get there
+        assert!(matches!(app.current_screen, Screen::SearchFields));
+    }
+);
 
-#[tokio::test]
-async fn test_ignores_gif_file() {
+test_with_both_regex_modes!(
+    test_update_search_results_filtered_dir,
+    |advanced_regex: bool| async move {
+        let temp_dir = &create_test_files! {
+            "dir1/file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "dir2/file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for testing",
+            },
+            "dir2/file3.txt" => {
+                "something",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "something testing",
+            }
+        };
+
+        let search_fields = SearchFields::with_values(r"testing", "f", false, "dir2")
+            .with_advanced_regex(advanced_regex);
+        search_and_replace_test(
+            temp_dir,
+            search_fields,
+            false,
+            vec![
+                (&Path::new("dir1").join("file1.txt"), 0),
+                (&Path::new("dir2").join("file2.txt"), 1),
+                (&Path::new("dir2").join("file3.txt"), 1),
+            ],
+        )
+        .await;
+
+        assert_test_files! {
+            temp_dir,
+            "dir1/file1.txt" => {
+                "This is a test file",
+                "It contains some test content",
+                "For testing purposes",
+            },
+            "dir2/file2.txt" => {
+                "Another test file",
+                "With different content",
+                "Also for f",
+            },
+            "dir2/file3.txt" => {
+                "something",
+                "123 bar[a-b]+.*bar)(baz 456",
+                "something f",
+            }
+        };
+    }
+);
+
+test_with_both_regex_modes!(test_ignores_gif_file, |advanced_regex: bool| async move {
     let temp_dir = &create_test_files! {
         "dir1/file1.txt" => {
             "This is a text file",
@@ -602,9 +639,11 @@ async fn test_ignores_gif_file() {
         }
     };
 
+    let search_fields =
+        SearchFields::with_values(r"is", "", false, "").with_advanced_regex(advanced_regex);
     search_and_replace_test(
         temp_dir,
-        SearchFields::with_values(r"is", "", false, ""),
+        search_fields,
         false,
         vec![
             (&Path::new("dir1").join("file1.txt"), 1),
@@ -626,87 +665,95 @@ async fn test_ignores_gif_file() {
             "Th  a text file",
         }
     };
-}
+});
 
-#[tokio::test]
-async fn test_ignores_hidden_files_by_default() {
-    let temp_dir = &create_test_files! {
-        "dir1/file1.txt" => {
-            "This is a text file",
-        },
-        ".dir2/file2.rs" => {
-            "This is a file in a hidden directory",
-        },
-        ".file3.txt" => {
-            "This is a hidden text file",
-        }
-    };
+test_with_both_regex_modes!(
+    test_ignores_hidden_files_by_default,
+    |advanced_regex: bool| async move {
+        let temp_dir = &create_test_files! {
+            "dir1/file1.txt" => {
+                "This is a text file",
+            },
+            ".dir2/file2.rs" => {
+                "This is a file in a hidden directory",
+            },
+            ".file3.txt" => {
+                "This is a hidden text file",
+            }
+        };
 
-    search_and_replace_test(
-        temp_dir,
-        SearchFields::with_values(r"\bis\b", "REPLACED", false, ""),
-        false,
-        vec![
-            (&Path::new("dir1").join("file1.txt"), 1),
-            (&Path::new(".dir2").join("file2.rs"), 0),
-            (Path::new(".file3.txt"), 0),
-        ],
-    )
-    .await;
+        let search_fields = SearchFields::with_values(r"\bis\b", "REPLACED", false, "")
+            .with_advanced_regex(advanced_regex);
+        search_and_replace_test(
+            temp_dir,
+            search_fields,
+            false,
+            vec![
+                (&Path::new("dir1").join("file1.txt"), 1),
+                (&Path::new(".dir2").join("file2.rs"), 0),
+                (Path::new(".file3.txt"), 0),
+            ],
+        )
+        .await;
 
-    assert_test_files! {
-        temp_dir,
-        "dir1/file1.txt" => {
-            "This REPLACED a text file",
-        },
-        ".dir2/file2.rs" => {
-            "This is a file in a hidden directory",
-        },
-        ".file3.txt" => {
-            "This is a hidden text file",
-        }
-    };
-}
+        assert_test_files! {
+            temp_dir,
+            "dir1/file1.txt" => {
+                "This REPLACED a text file",
+            },
+            ".dir2/file2.rs" => {
+                "This is a file in a hidden directory",
+            },
+            ".file3.txt" => {
+                "This is a hidden text file",
+            }
+        };
+    }
+);
 
-#[tokio::test]
-async fn test_includes_hidden_files_with_flag() {
-    let temp_dir = &create_test_files! {
-        "dir1/file1.txt" => {
-            "This is a text file",
-        },
-        ".dir2/file2.rs" => {
-            "This is a file in a hidden directory",
-        },
-        ".file3.txt" => {
-            "This is a hidden text file",
-        }
-    };
+test_with_both_regex_modes!(
+    test_includes_hidden_files_with_flag,
+    |advanced_regex: bool| async move {
+        let temp_dir = &create_test_files! {
+            "dir1/file1.txt" => {
+                "This is a text file",
+            },
+            ".dir2/file2.rs" => {
+                "This is a file in a hidden directory",
+            },
+            ".file3.txt" => {
+                "This is a hidden text file",
+            }
+        };
 
-    search_and_replace_test(
-        temp_dir,
-        SearchFields::with_values(r"\bis\b", "REPLACED", false, ""),
-        true,
-        vec![
-            (&Path::new("dir1").join("file1.txt"), 1),
-            (&Path::new(".dir2").join("file2.rs"), 1),
-            (Path::new(".file3.txt"), 1),
-        ],
-    )
-    .await;
+        let search_fields = SearchFields::with_values(r"\bis\b", "REPLACED", false, "")
+            .with_advanced_regex(advanced_regex);
+        search_and_replace_test(
+            temp_dir,
+            search_fields,
+            true,
+            vec![
+                (&Path::new("dir1").join("file1.txt"), 1),
+                (&Path::new(".dir2").join("file2.rs"), 1),
+                (Path::new(".file3.txt"), 1),
+            ],
+        )
+        .await;
 
-    assert_test_files! {
-        temp_dir,
-        "dir1/file1.txt" => {
-            "This REPLACED a text file",
-        },
-        ".dir2/file2.rs" => {
-            "This REPLACED a file in a hidden directory",
-        },
-        ".file3.txt" => {
-            "This REPLACED a hidden text file",
-        }
-    };
-}
+        assert_test_files! {
+            temp_dir,
+            "dir1/file1.txt" => {
+                "This REPLACED a text file",
+            },
+            ".dir2/file2.rs" => {
+                "This REPLACED a file in a hidden directory",
+            },
+            ".file3.txt" => {
+                "This REPLACED a hidden text file",
+            }
+        };
+    }
+);
 
 // TODO:
 // - Add:

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -355,6 +355,7 @@ macro_rules! test_with_both_regex_modes {
         mod $name {
             use super::*;
 
+            // TODO: run max n at a time, rather than serially
             #[tokio::test]
             #[serial]
             async fn with_advanced_regex() {

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -82,7 +82,7 @@ async fn test_replace_state() {
 #[tokio::test]
 async fn test_app_reset() {
     let events = EventHandler::new();
-    let mut app = App::new(None, false, events.app_event_sender);
+    let mut app = App::new(None, false, false, events.app_event_sender);
     app.current_screen = Screen::Results(ReplaceState {
         num_successes: 5,
         num_ignored: 2,
@@ -98,7 +98,7 @@ async fn test_app_reset() {
 #[tokio::test]
 async fn test_back_from_results() {
     let events = EventHandler::new();
-    let mut app = App::new(None, false, events.app_event_sender);
+    let mut app = App::new(None, false, false, events.app_event_sender);
     app.current_screen = Screen::SearchComplete(SearchState {
         results: vec![],
         selected: 0,
@@ -125,7 +125,7 @@ async fn test_back_from_results() {
 #[tokio::test]
 async fn test_error_popup() {
     let events = EventHandler::new();
-    let mut app = App::new(None, false, events.app_event_sender.clone());
+    let mut app = App::new(None, false, false, events.app_event_sender.clone());
     app.current_screen = Screen::SearchFields;
     app.search_fields =
         SearchFields::with_values("search invalid regex(", "replacement", false, "");
@@ -281,6 +281,7 @@ fn setup_app(temp_dir: &TempDir, search_fields: SearchFields, include_hidden: bo
     let mut app = App::new(
         Some(temp_dir.path().to_path_buf()),
         include_hidden,
+        false,
         events.app_event_sender,
     );
     app.search_fields = search_fields;

--- a/tests/fields.rs
+++ b/tests/fields.rs
@@ -93,6 +93,7 @@ fn test_search_fields() {
         ],
         highlighted: 0,
         show_error_popup: false,
+        advanced_regex: false,
     };
 
     // Test focus navigation
@@ -139,7 +140,7 @@ fn test_search_fields() {
     let search_type = search_fields.search_type().unwrap();
     match search_type {
         SearchType::Fixed(s) => assert_eq!(s, "test search"),
-        SearchType::Pattern(_) => panic!("Expected Fixed, got Pattern"),
+        _ => panic!("Expected Fixed, got {:?}", search_type),
     }
 
     search_fields
@@ -149,6 +150,6 @@ fn test_search_fields() {
     let search_type = search_fields.search_type().unwrap();
     match search_type {
         SearchType::Pattern(_) => {}
-        SearchType::Fixed(_) => panic!("Expected Pattern, got Fixed"),
+        _ => panic!("Expected Pattern, got {:?}", search_type),
     }
 }

--- a/tests/fields.rs
+++ b/tests/fields.rs
@@ -1,10 +1,5 @@
-use parking_lot::RwLock;
 use ratatui::crossterm::event::{KeyCode, KeyModifiers};
-use scooter::{
-    parsed_fields::SearchType, CheckboxField, Field, FieldName, SearchField, SearchFields,
-    TextField,
-};
-use std::sync::Arc;
+use scooter::{parsed_fields::SearchType, CheckboxField, SearchFields, TextField};
 
 #[test]
 fn test_text_field_operations() {
@@ -72,29 +67,7 @@ fn test_checkbox_field() {
 
 #[test]
 fn test_search_fields() {
-    let mut search_fields = SearchFields {
-        fields: [
-            SearchField {
-                name: FieldName::Search,
-                field: Arc::new(RwLock::new(Field::text(""))),
-            },
-            SearchField {
-                name: FieldName::Replace,
-                field: Arc::new(RwLock::new(Field::text(""))),
-            },
-            SearchField {
-                name: FieldName::FixedStrings,
-                field: Arc::new(RwLock::new(Field::checkbox(false))),
-            },
-            SearchField {
-                name: FieldName::PathPattern,
-                field: Arc::new(RwLock::new(Field::text(""))),
-            },
-        ],
-        highlighted: 0,
-        show_error_popup: false,
-        advanced_regex: false,
-    };
+    let mut search_fields = SearchFields::with_values("", "", false, "");
 
     // Test focus navigation
     assert_eq!(search_fields.highlighted, 0);


### PR DESCRIPTION
Allows users to use the [fancy-regex](https://docs.rs/fancy-regex/latest/fancy_regex/) (rather than [regex](https://github.com/rust-lang/regex)) crate, which adds additional features like negative lookahead at the expense of speed. This can be enabled using the `--advanced_regex` (`-a`) CLI flag.

Resolves https://github.com/thomasschafer/scooter/issues/44

To do:
- Do some more manual testing
- Add tests for advanced regex functionality