### PR TITLE
Make replacement async

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
 
-use crate::app::SearchState;
+use crate::app::ReplaceState;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ReplaceResult {
@@ -25,13 +25,13 @@ pub struct SearchResult {
 pub enum AppEvent {
     Rerender,
     PerformSearch,
-    PerformReplacement(SearchState),
 }
 
 #[derive(Debug)]
 pub enum BackgroundProcessingEvent {
     AddSearchResult(SearchResult),
     SearchCompleted,
+    ReplacementCompleted(ReplaceState),
 }
 
 #[derive(Debug)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -434,7 +434,7 @@ pub fn render(app: &App, frame: &mut Frame<'_>) {
         Screen::SearchProgressing(_) | Screen::SearchComplete(_) => {
             Box::new(render_confirmation_view)
         }
-        Screen::PerformingReplacement => {
+        Screen::PerformingReplacement(_) => {
             Box::new(render_loading_view("Performing replacement...".to_owned()))
         }
         Screen::Results(ref replace_state) => Box::new(render_results_view(replace_state)),
@@ -460,7 +460,7 @@ pub fn render(app: &App, frame: &mut Frame<'_>) {
             ]);
             keys
         }
-        Screen::PerformingReplacement => vec![],
+        Screen::PerformingReplacement(_) => vec![],
         Screen::Results(ref replace_state) => {
             if !replace_state.errors.is_empty() {
                 vec!["<j> down", "<k> up"]
@@ -470,11 +470,8 @@ pub fn render(app: &App, frame: &mut Frame<'_>) {
         }
     };
 
-    let additional_keys = if matches!(app.current_screen, Screen::PerformingReplacement) {
-        vec![]
-    } else {
-        vec!["<C-r> reset", "<esc> quit"]
-    };
+    let additional_keys = ["<C-r> reset", "<esc> quit"];
+
     let all_keys = current_keys
         .iter()
         .chain(additional_keys.iter())


### PR DESCRIPTION
This PR moves the replacement to a separate thread (as has already been done with searching), allowing it to be cancelled part-way through, and ensuring that keypresses on the replacement screen do not get queued up and executed on the search results screen.