### PR TITLE
Use tempfiles when replacing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ serde_json = "1.0.133"
 serial_test = "3.2.0"
 similar = "2.6.0"
 simple-log = "2.1.1"
+tempfile = "3.14.0"
 tokio = { version = "1.41.1", features = ["full"] }
 
 [dev-dependencies]
-tempfile = "3.14.0"
 rand = "0.8.5"
 
 [lib]


### PR DESCRIPTION
Currently when replacing we're manually creating temporary files in the same dir as the original file with the `.tmp` extension, but this could cause issues if such a file already exists or when the thread is killed performing the replacement. This PR uses the `tempfile` crate instead to resolve both of these issues.