### PR TITLE
Don't include platform in binary name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,12 +118,10 @@ jobs:
         VERSION="${{ needs.prepare-release.outputs.version }}"
         if [ "${{ runner.os }}" = "Windows" ]; then
           ARCHIVE="${{ env.BINARY_NAME }}-v${VERSION}-${{ matrix.target }}.zip"
-          mv "${{ env.BINARY_NAME }}.exe" "${{ env.BINARY_NAME }}-${{ matrix.target }}.exe"
-          7z a "$ARCHIVE" "${{ env.BINARY_NAME }}-${{ matrix.target }}.exe"
+          7z a "$ARCHIVE" "${{ env.BINARY_NAME }}.exe"
         else
           ARCHIVE="${{ env.BINARY_NAME }}-v${VERSION}-${{ matrix.target }}.tar.gz"
-          mv "${{ env.BINARY_NAME }}" "${{ env.BINARY_NAME }}-${{ matrix.target }}"
-          tar -czvf "$ARCHIVE" "${{ env.BINARY_NAME }}-${{ matrix.target }}"
+          tar -czvf "$ARCHIVE" "${{ env.BINARY_NAME }}"
         fi
 
         # Generate checksums
@@ -139,12 +137,12 @@ jobs:
         case "${{ matrix.target }}" in
           *windows*)
             7z x -y "$ASSET"
-            ./${{ env.BINARY_NAME }}-${{ matrix.target }}.exe --version ;;
+            ./${{ env.BINARY_NAME }}.exe --version ;;
           aarch64*)
             echo "Can't test an ARM binary on a AMD64 runner" ;;
           *)
             tar -xvzf "$ASSET"
-            ./${{ env.BINARY_NAME }}-${{ matrix.target }} --version ;;
+            ./${{ env.BINARY_NAME }} --version ;;
         esac
 
     - name: Upload to release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "scooter"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scooter"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["thomasschafer97@gmail.com"]
 license = "MIT"


### PR DESCRIPTION
Currently binaries include the target in their name, e.g. `scooter-aarch64-apple-darwin`, which is unnecessary given that the archive already includes the target. Removing the target from the binary name (i.e. naming binaries just `scooter` instead) also means that users don't need to rename when adding the binary to their `PATH`.

See [here](https://github.com/thomasschafer/scooter/issues/70#issuecomment-2642519864) for further context.