### PR TITLE
Add CmdLine args

### DIFF
--- a/scooter/src/app.rs
+++ b/scooter/src/app.rs
@@ -504,6 +504,7 @@ pub struct App {
     pub search_fields: SearchFields,
     errors: Vec<AppError>,
     pub directory: PathBuf,
+    pub search_term: String,
     include_hidden: bool,
     pub config: Config,
 
@@ -515,6 +516,7 @@ const BINARY_EXTENSIONS: &[&str] = &["png", "gif", "jpg", "jpeg", "ico", "svg", 
 impl App {
     fn new(
         directory: Option<PathBuf>,
+        search_term: Option<String>,
         include_hidden: bool,
         advanced_regex: bool,
         event_sender: UnboundedSender<Event>,
@@ -526,13 +528,24 @@ impl App {
             None => current_dir().unwrap(),
         };
 
-        let search_fields = SearchFields::with_default_values().with_advanced_regex(advanced_regex);
+        let search_term = match search_term {
+            Some(st) => st.to_string(),
+            None => String::new(),
+        };
+
+        let mut search_fields =
+            SearchFields::with_default_values().with_advanced_regex(advanced_regex);
+        if !search_term.is_empty() {
+            search_fields.search_mut().text = search_term.clone();
+            search_fields.focus_next();
+        }
 
         Self {
             current_screen: Screen::SearchFields,
             search_fields,
             errors: vec![],
             directory,
+            search_term,
             include_hidden,
             config,
             event_sender,
@@ -541,11 +554,18 @@ impl App {
 
     pub fn new_with_receiver(
         directory: Option<PathBuf>,
+        search_term: Option<String>,
         include_hidden: bool,
         advanced_regex: bool,
     ) -> (Self, UnboundedReceiver<Event>) {
         let (event_sender, app_event_receiver) = mpsc::unbounded_channel();
-        let app = Self::new(directory, include_hidden, advanced_regex, event_sender);
+        let app = Self::new(
+            directory,
+            search_term,
+            include_hidden,
+            advanced_regex,
+            event_sender,
+        );
         (app, app_event_receiver)
     }
 
@@ -572,6 +592,7 @@ impl App {
         self.cancel_replacement();
         *self = Self::new(
             Some(self.directory.clone()),
+            Some(self.search_term.clone()),
             self.include_hidden,
             self.search_fields.advanced_regex,
             self.event_sender.clone(),
@@ -1250,7 +1271,7 @@ mod tests {
 
     fn build_test_app(results: Vec<SearchResult>) -> App {
         let (event_sender, _) = mpsc::unbounded_channel();
-        let mut app = App::new(None, false, false, event_sender);
+        let mut app = App::new(None, None, false, false, event_sender);
         app.current_screen = Screen::SearchComplete(SearchState::with_results(results));
         app
     }

--- a/scooter/src/app_runner.rs
+++ b/scooter/src/app_runner.rs
@@ -25,6 +25,7 @@ use crate::{
 
 pub struct AppConfig {
     pub directory: Option<String>,
+    pub search_term: Option<String>,
     pub hidden: bool,
     pub advanced_regex: bool,
     pub log_level: LevelFilter,
@@ -82,8 +83,13 @@ where
             Some(d) => Some(validate_directory(&d)?),
         };
 
+        let search_term = match config.search_term {
+            None => None,
+            Some(st) => Some(st.to_string()),
+        };
+
         let (app, event_receiver) =
-            App::new_with_receiver(directory, config.hidden, config.advanced_regex);
+            App::new_with_receiver(directory, search_term, config.hidden, config.advanced_regex);
 
         let terminal = Terminal::new(backend)?;
         let tui = Tui::new(terminal);

--- a/scooter/src/main.rs
+++ b/scooter/src/main.rs
@@ -22,6 +22,9 @@ struct Args {
     #[arg(index = 1)]
     directory: Option<String>,
 
+    #[arg(index = 2)]
+    search_term: Option<String>,
+
     /// Include hidden files and directories, such as those whose name starts with a dot (.)
     #[arg(short = '.', long, default_value = "false")]
     hidden: bool,
@@ -47,6 +50,7 @@ impl From<Args> for AppConfig {
     fn from(args: Args) -> Self {
         Self {
             directory: args.directory,
+            search_term: args.search_term,
             hidden: args.hidden,
             advanced_regex: args.advanced_regex,
             log_level: args.log_level,


### PR DESCRIPTION
I'm not a rust developer by day but I've managed to add a quick implementation of adding a "search_term" as a CLI arg.

I'm cool with adding the rest with a little direction.  Why I've only added 1.

