### PR TITLE
Detect true colour and update colouring accordingly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "simple-log",
  "syntect",
  "tempfile",
+ "termini",
  "tokio",
  "toml",
 ]
@@ -1568,6 +1569,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.2",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termini"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad441d87dd98bc5eeb31cf2fb7e4839968763006b478efb38668a3bf9da0d59"
+dependencies = [
+ "home",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ wget -P ~/.config/scooter/themes https://github.com/catppuccin/bat/raw/main/them
 ```
 and then set `syntax_highlighting_theme = "Catppuccin Macchiato"`.
 
+### `[style]` section
+
+#### `true_color`
+
+Force enable or disable true colour. `true` forces true colour (supported by most modern terminals but not e.g. Apple Terminal), while `false` forces 256 colours (supported almost all terminals including Apple Terminal).
+If ommitted, Scooter will attempt to determine whether the terminal being used supports true colour.
+
 <!-- CONFIG END -->
 
 

--- a/README.md
+++ b/README.md
@@ -170,16 +170,17 @@ with the file path of the seach result, and `%line`, which will be replaced with
 [editor_open]
 command = "vi %file +%line"
 ```
+If not set explicitly, Scooter will attempt to use the editor set by the `$EDITOR` environment variable.
 
 #### `exit`
 
-Whether to exit after running the command defined by `editor_open.command`.
+Whether to exit Scooter after running the command defined by `editor_open.command`. Defaults to `false`.
 
 ### `[preview]` section
 
 #### `syntax_highlighting`
 
-Whether to apply syntax highlighting to the preview.
+Whether to apply syntax highlighting to the preview. Defaults to `true`.
 
 #### `syntax_highlighting_theme`
 
@@ -199,8 +200,8 @@ and then set `syntax_highlighting_theme = "Catppuccin Macchiato"`.
 
 #### `true_color`
 
-Force enable or disable true colour. `true` forces true colour (supported by most modern terminals but not e.g. Apple Terminal), while `false` forces 256 colours (supported almost all terminals including Apple Terminal).
-If ommitted, Scooter will attempt to determine whether the terminal being used supports true colour.
+Force enable or disable true color. `true` forces true color (supported by most modern terminals but not e.g. Apple Terminal), while `false` forces 256 colors (supported by almost all terminals including Apple Terminal).
+If omitted, Scooter will attempt to determine whether the terminal being used supports true color.
 
 <!-- CONFIG END -->
 

--- a/scooter/Cargo.toml
+++ b/scooter/Cargo.toml
@@ -31,6 +31,7 @@ similar = "2.7.0"
 simple-log = "2.3.0"
 syntect = "5.2.0"
 tempfile = "3.19.1"
+termini = "1.0.0"
 tokio = { version = "1.44.2", features = ["full"] }
 toml = "0.8.20"
 

--- a/scooter/src/config.rs
+++ b/scooter/src/config.rs
@@ -39,6 +39,31 @@ pub struct Config {
     pub editor_open: EditorOpenConfig,
     #[serde(default)]
     pub preview: PreviewConfig,
+    #[serde(default)]
+    pub style: StyleConfig,
+}
+
+impl Config {
+    /// Returns `None` if the user wants syntax highlighting disabled, otherwise `Some(theme)` where `theme`
+    /// is the user's selected theme or otherwise the default
+    pub(crate) fn get_theme(&self) -> Option<&Theme> {
+        if self.preview.syntax_highlighting {
+            Some(&self.preview.syntax_highlighting_theme)
+        } else {
+            None
+        }
+    }
+}
+
+pub fn load_config() -> anyhow::Result<Config> {
+    let config_file = &config_file();
+    if fs::exists(config_file)? {
+        let contents = fs::read_to_string(config_file)?;
+        let config = toml::from_str(&contents)?;
+        Ok(config)
+    } else {
+        Ok(Config::default())
+    }
 }
 
 impl Default for Config {
@@ -110,7 +135,7 @@ fn default_syntax_highlighting_theme() -> Theme {
 
 impl Default for PreviewConfig {
     fn default() -> Self {
-        PreviewConfig {
+        Self {
             syntax_highlighting: default_syntax_highlighting(),
             syntax_highlighting_theme: default_syntax_highlighting_theme(),
         }
@@ -136,26 +161,45 @@ where
     load_theme(&theme_name).map_err(de::Error::custom)
 }
 
-impl Config {
-    /// Returns `None` if the user wants syntax highlighting disabled, otherwise `Some(theme)` where `theme`
-    /// is the user's selected theme or otherwise the default
-    pub(crate) fn get_theme(&self) -> Option<&Theme> {
-        if self.preview.syntax_highlighting {
-            Some(&self.preview.syntax_highlighting_theme)
-        } else {
-            None
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct StyleConfig {
+    /// Force enable or disable true colour. `true` forces true colour (supported by most modern terminals but not e.g. Apple Terminal), while `false` forces 256 colours (supported almost all terminals including Apple Terminal).
+    /// If ommitted, Scooter will attempt to determine whether the terminal being used supports true colour.
+    #[serde(default = "detect_true_colour")]
+    pub true_color: bool,
+}
+
+impl Default for StyleConfig {
+    fn default() -> Self {
+        Self {
+            true_color: detect_true_colour(),
         }
     }
 }
 
-pub fn load_config() -> anyhow::Result<Config> {
-    let config_file = &config_file();
-    if fs::exists(config_file)? {
-        let contents = fs::read_to_string(config_file)?;
-        let config = toml::from_str(&contents)?;
-        Ok(config)
-    } else {
-        Ok(Config::default())
+#[cfg(windows)]
+fn detect_true_colour() -> bool {
+    true
+}
+
+// Copied from Helix
+#[cfg(not(windows))]
+fn detect_true_colour() -> bool {
+    if matches!(
+        std::env::var("COLORTERM").map(|v| matches!(v.as_str(), "truecolor" | "24bit")),
+        Ok(true)
+    ) {
+        return true;
+    }
+
+    match termini::TermInfo::from_env() {
+        Ok(t) => {
+            t.extended_cap("RGB").is_some()
+                || t.extended_cap("Tc").is_some()
+                || (t.extended_cap("setrgbf").is_some() && t.extended_cap("setrgbb").is_some())
+        }
+        Err(_) => false,
     }
 }
 
@@ -252,7 +296,8 @@ syntax_highlighting_theme = "Solarized (light)"
                 preview: PreviewConfig {
                     syntax_highlighting: false,
                     syntax_highlighting_theme: load_theme("Solarized (light)").unwrap(),
-                }
+                },
+                style: StyleConfig { true_color: true },
             }
         );
 
@@ -289,6 +334,7 @@ command = "vim %file +%line"
                 syntax_highlighting: false,
                 syntax_highlighting_theme: load_theme("base16-ocean.dark").unwrap(),
             },
+            style: StyleConfig { true_color: true },
         };
         assert_eq!(config.get_theme(), None);
     }
@@ -301,6 +347,7 @@ command = "vim %file +%line"
                 syntax_highlighting: true,
                 syntax_highlighting_theme: load_theme("base16-ocean.dark").unwrap(),
             },
+            style: StyleConfig { true_color: true },
         };
         assert_eq!(
             config.get_theme(),

--- a/scooter/src/config.rs
+++ b/scooter/src/config.rs
@@ -85,9 +85,10 @@ pub struct EditorOpenConfig {
     /// [editor_open]
     /// command = "vi %file +%line"
     /// ```
+    /// If not set explicitly, Scooter will attempt to use the editor set by the `$EDITOR` environment variable.
     #[serde(default)]
     pub command: Option<String>,
-    /// Whether to exit after running the command defined by `editor_open.command`.
+    /// Whether to exit Scooter after running the command defined by `editor_open.command`. Defaults to `false`.
     #[serde(default = "default_exit")]
     pub exit: bool,
 }
@@ -104,7 +105,7 @@ impl Default for EditorOpenConfig {
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct PreviewConfig {
-    /// Whether to apply syntax highlighting to the preview.
+    /// Whether to apply syntax highlighting to the preview. Defaults to `true`.
     #[serde(default = "default_syntax_highlighting")]
     pub syntax_highlighting: bool,
     /// The theme to use when syntax highlighting is enabled.
@@ -164,8 +165,8 @@ where
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct StyleConfig {
-    /// Force enable or disable true colour. `true` forces true colour (supported by most modern terminals but not e.g. Apple Terminal), while `false` forces 256 colours (supported almost all terminals including Apple Terminal).
-    /// If ommitted, Scooter will attempt to determine whether the terminal being used supports true colour.
+    /// Force enable or disable true color. `true` forces true color (supported by most modern terminals but not e.g. Apple Terminal), while `false` forces 256 colors (supported by almost all terminals including Apple Terminal).
+    /// If omitted, Scooter will attempt to determine whether the terminal being used supports true color.
     #[serde(default = "detect_true_colour")]
     pub true_color: bool,
 }
@@ -297,7 +298,9 @@ syntax_highlighting_theme = "Solarized (light)"
                     syntax_highlighting: false,
                     syntax_highlighting_theme: load_theme("Solarized (light)").unwrap(),
                 },
-                style: StyleConfig { true_color: true },
+                style: StyleConfig {
+                    true_color: detect_true_colour()
+                },
             }
         );
 
@@ -334,7 +337,9 @@ command = "vim %file +%line"
                 syntax_highlighting: false,
                 syntax_highlighting_theme: load_theme("base16-ocean.dark").unwrap(),
             },
-            style: StyleConfig { true_color: true },
+            style: StyleConfig {
+                true_color: detect_true_colour(),
+            },
         };
         assert_eq!(config.get_theme(), None);
     }
@@ -347,7 +352,9 @@ command = "vim %file +%line"
                 syntax_highlighting: true,
                 syntax_highlighting_theme: load_theme("base16-ocean.dark").unwrap(),
             },
-            style: StyleConfig { true_color: true },
+            style: StyleConfig {
+                true_color: detect_true_colour(),
+            },
         };
         assert_eq!(
             config.get_theme(),

--- a/scooter/src/fields.rs
+++ b/scooter/src/fields.rs
@@ -1,10 +1,6 @@
 use ratatui::{
     crossterm::event::{KeyCode, KeyModifiers},
-    layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style, Stylize},
-    text::{Line, Span, Text},
-    widgets::{Block, Paragraph},
-    Frame,
+    text::Text,
 };
 
 #[derive(Clone, Debug)]
@@ -275,57 +271,6 @@ impl Field {
         match self {
             Field::Text(f) => f.error.clone(),
             Field::Checkbox(f) => f.error.clone(),
-        }
-    }
-
-    fn create_title_spans<'a>(&self, title: &'a str, highlighted: bool) -> Vec<Span<'a>> {
-        let title_style = Style::new().fg(if highlighted {
-            Color::Green
-        } else {
-            Color::Reset
-        });
-
-        let mut spans = vec![Span::styled(title, title_style)];
-        if let Some(error) = self.error() {
-            spans.push(Span::styled(
-                format!(" (Error: {})", error.short),
-                Style::new().fg(Color::Red),
-            ));
-        }
-        spans
-    }
-
-    pub fn render(&self, frame: &mut Frame<'_>, area: Rect, title: &str, highlighted: bool) {
-        let mut block = Block::bordered();
-        if highlighted {
-            block = block.border_style(Style::new().green());
-        }
-
-        let title_spans = self.create_title_spans(title, highlighted);
-
-        match self {
-            Field::Text(f) => {
-                block = block.title(Line::from(title_spans));
-                frame.render_widget(Paragraph::new(f.text()).block(block), area);
-            }
-            Field::Checkbox(f) => {
-                let inner_chunks = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .constraints([Constraint::Length(5), Constraint::Min(0)])
-                    .split(area);
-
-                frame.render_widget(
-                    Paragraph::new(if f.checked { " X " } else { "" }).block(block),
-                    inner_chunks[0],
-                );
-
-                let mut spans = vec![Span::raw(" ")];
-                spans.extend(title_spans);
-
-                let checkbox_text = vec![Line::from(Span::raw("")), Line::from(spans)];
-
-                frame.render_widget(Paragraph::new(checkbox_text), inner_chunks[1]);
-            }
         }
     }
 }

--- a/scooter/src/tui.rs
+++ b/scooter/src/tui.rs
@@ -39,7 +39,7 @@ impl<B: Backend + 'static> Tui<B> {
     }
 
     pub fn draw(&mut self, app: &mut App) -> anyhow::Result<()> {
-        self.terminal.draw(|frame| ui::render(app, frame))?;
+        self.terminal.draw(|frame| ui::view::render(app, frame))?;
         Ok(())
     }
 

--- a/scooter/src/ui/colour.rs
+++ b/scooter/src/ui/colour.rs
@@ -1,0 +1,140 @@
+use ratatui::style::Color;
+use syntect::highlighting::Color as SyntectColour;
+
+// Finds the index (0-5) for an RGB component corresponding to the closest xterm cube level:
+// 0, 95, 135, 175, 215 or 255.
+#[allow(clippy::inline_always)]
+#[inline(always)]
+fn cube_idx(value: u8) -> u8 {
+    if value < 48 {
+        0
+    } else if value < 115 {
+        1
+    } else if value < 155 {
+        2
+    } else if value < 195 {
+        3
+    } else if value < 235 {
+        4
+    } else {
+        5
+    }
+}
+
+/// Converts an RGB color to the closest xterm 256-color palette index.
+/// This function prioritizes speed while maintaining reasonable accuracy.
+///
+/// The 256-color palette consists of:
+/// - 0-15: Standard and high-intensity ANSI colors (not directly targeted here, but black and white are handled via cube/grayscale equivalents).
+/// - 16-231: A 6x6x6 color cube.
+/// - 232-255: A 24-step grayscale ramp.
+fn to_256_colour(r: u8, g: u8, b: u8) -> u8 {
+    if r == g && g == b {
+        if r < 8 {
+            return 16;
+        }
+        if r > 247 {
+            return 231;
+        }
+        return 232 + ((r - 8) / 10);
+    }
+
+    16 + (cube_idx(r) * 36) + (cube_idx(g) * 6) + cube_idx(b)
+}
+
+pub fn to_ratatui_colour(colour: SyntectColour, true_colour: bool) -> Color {
+    if true_colour {
+        Color::Rgb(colour.r, colour.g, colour.b)
+    } else {
+        Color::Indexed(to_256_colour(colour.r, colour.g, colour.b))
+    }
+}
+
+#[allow(clippy::identity_op, clippy::erasing_op)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_256_colour_black() {
+        // Test black (0,0,0) should map to color 16
+        assert_eq!(to_256_colour(0, 0, 0), 16);
+        // Near-black values should also map to 16
+        assert_eq!(to_256_colour(5, 5, 5), 16);
+    }
+
+    #[test]
+    fn test_to_256_colour_white() {
+        // Test white (255,255,255) should map to color 231 (end of color cube)
+        assert_eq!(to_256_colour(255, 255, 255), 231);
+        // Near-white values should also map to 231
+        assert_eq!(to_256_colour(250, 250, 250), 231);
+    }
+
+    #[test]
+    fn test_to_256_colour_grayscale() {
+        // Test various grayscale values in between black and white
+        // These should map to the grayscale ramp (232-255)
+        assert_eq!(to_256_colour(8, 8, 8), 232);
+        assert_eq!(to_256_colour(18, 18, 18), 233);
+        assert_eq!(to_256_colour(28, 18, 28), 16 + (0 * 36) + (0 * 6) + 0); // Not grayscale, should go to cube
+        assert_eq!(to_256_colour(128, 128, 128), 244);
+        assert_eq!(to_256_colour(247, 247, 247), 255); // Last grayscale color
+    }
+
+    #[test]
+    fn test_to_256_colour_primary_colors() {
+        // Test primary colors (fully saturated R, G, B)
+        assert_eq!(to_256_colour(255, 0, 0), 196); // Pure red is 16 + (5*36) + (0*6) + 0 = 196
+        assert_eq!(to_256_colour(0, 255, 0), 46); // Pure green is 16 + (0*36) + (5*6) + 0 = 46
+        assert_eq!(to_256_colour(0, 0, 255), 21); // Pure blue is 16 + (0*36) + (0*6) + 5 = 21
+    }
+
+    #[test]
+    fn test_to_256_colour_secondary_colors() {
+        // Test secondary colors
+        assert_eq!(to_256_colour(255, 255, 0), 226); // Yellow is 16 + (5*36) + (5*6) + 0 = 226
+        assert_eq!(to_256_colour(255, 0, 255), 201); // Magenta is 16 + (5*36) + (0*6) + 5 = 201
+        assert_eq!(to_256_colour(0, 255, 255), 51); // Cyan is 16 + (0*36) + (5*6) + 5 = 51
+    }
+
+    #[test]
+    fn test_to_256_colour_color_thresholds() {
+        // Test color threshold boundaries for the cube_idx function
+
+        // Just below and above the first threshold (48)
+        assert_eq!(cube_idx(47), 0);
+        assert_eq!(cube_idx(48), 1);
+
+        // Just below and above the second threshold (115)
+        assert_eq!(cube_idx(114), 1);
+        assert_eq!(cube_idx(115), 2);
+
+        // Just below and above the third threshold (155)
+        assert_eq!(cube_idx(154), 2);
+        assert_eq!(cube_idx(155), 3);
+
+        // Just below and above the fourth threshold (195)
+        assert_eq!(cube_idx(194), 3);
+        assert_eq!(cube_idx(195), 4);
+
+        // Just below and above the fifth threshold (235)
+        assert_eq!(cube_idx(234), 4);
+        assert_eq!(cube_idx(235), 5);
+    }
+
+    #[test]
+    fn test_specific_xterm_values() {
+        // The 6 specific red values in the cube
+        assert_eq!(to_256_colour(0, 0, 0), 16); // Black (also grayscale)
+        assert_eq!(to_256_colour(95, 0, 0), 52); // Dark red
+        assert_eq!(to_256_colour(135, 0, 0), 88); // Medium-dark red
+        assert_eq!(to_256_colour(175, 0, 0), 124); // Medium red
+        assert_eq!(to_256_colour(215, 0, 0), 160); // Medium-bright red
+        assert_eq!(to_256_colour(255, 0, 0), 196); // Bright red
+
+        // A few exact color cube combinations
+        assert_eq!(to_256_colour(95, 135, 175), 16 + (1 * 36) + (2 * 6) + 3);
+        assert_eq!(to_256_colour(215, 95, 135), 16 + (4 * 36) + (1 * 6) + 2);
+    }
+}

--- a/scooter/src/ui/mod.rs
+++ b/scooter/src/ui/mod.rs
@@ -1,0 +1,2 @@
+pub mod colour;
+pub mod view;


### PR DESCRIPTION
Currently syntax highlighting looks terrible on non-true colour terminals such as Apple Terminal. This PR adds a `true_color` config option, and attempts to auto-detect if not set via config. Based on this value, colours will then be rendered as true colour (RGB) or 256 colour.