### PR TITLE
Add `--immediate-search` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,20 @@ You can pre-populate the search fields using command-line flags, for instance:
 
 ```sh
 scooter \
-  --search-text "old_function" \
-  --replace-text "new_function" \
+  --search-text "old" \
+  --replace-text "new" \
   --fixed-strings \
   --files-to-include "*.rs,*.py"
 ```
 
 Note that, by default, pre-populated fields are disabled in the UI. To make these fields editable by default, you can set `search.disable_prepopulated_fields` to `false` in your config - see [here](#disable_prepopulated_fields).
 You can also temporarily unlock the pre-populated fields with `ctrl+u`.
+
+When pre-populating the fields in this way, you can skip the initial search screen entirely and jump straight to searching with the `--immediate-search` flag, e.g.:
+
+```sh
+scooter --search-text "old" --replace-text "new" --immediate-search
+```
 
 Run `scooter --help` to see the full list of command-line args that can be used to pre-populate fields.
 

--- a/scooter/src/app.rs
+++ b/scooter/src/app.rs
@@ -498,7 +498,7 @@ impl<'a> App {
                 include_hidden: self.include_hidden,
                 advanced_regex: self.search_fields.advanced_regex,
                 immediate_search: false,
-            }, // Don't trigger immediate search on reset
+            },
         );
     }
 

--- a/scooter/src/app_runner.rs
+++ b/scooter/src/app_runner.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-    app::{App, AppError, Event, EventHandlingResult},
+    app::{App, AppError, AppRunConfig, Event, EventHandlingResult},
     fields::SearchFieldValues,
     logging::setup_logging,
     tui::Tui,
@@ -27,10 +27,11 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AppConfig<'a> {
     pub directory: Option<String>,
-    pub hidden: bool,
+    pub include_hidden: bool,
     pub advanced_regex: bool,
     pub log_level: LevelFilter,
     pub search_field_values: SearchFieldValues<'a>,
+    pub immediate_search: bool,
 }
 
 pub trait EventStream:
@@ -87,9 +88,12 @@ where
 
         let (app, event_receiver) = App::new_with_receiver(
             directory,
-            config.hidden,
-            config.advanced_regex,
             &config.search_field_values,
+            &AppRunConfig {
+                include_hidden: config.include_hidden,
+                advanced_regex: config.advanced_regex,
+                immediate_search: config.immediate_search,
+            },
         );
 
         let terminal = Terminal::new(backend)?;

--- a/scooter/src/main.rs
+++ b/scooter/src/main.rs
@@ -71,6 +71,10 @@ struct Args {
     /// Glob patterns, separated by commas (,), that file paths must not match
     #[arg(short = 'E', long)]
     files_to_exclude: Option<String>,
+
+    /// Search immediately using values set by flags (e.g. `--search_text`), rather than showing search fields first
+    #[arg(short = 'S', long)]
+    immediate_search: bool,
 }
 
 fn parse_log_level(s: &str) -> Result<LevelFilter, String> {
@@ -104,10 +108,11 @@ impl<'a> From<&'a Args> for AppConfig<'a> {
 
         Self {
             directory: args.directory.clone(),
-            hidden: args.hidden,
+            include_hidden: args.hidden,
             advanced_regex: args.advanced_regex,
             log_level: args.log_level,
             search_field_values,
+            immediate_search: args.immediate_search,
         }
     }
 }

--- a/scooter/tests/app_runner.rs
+++ b/scooter/tests/app_runner.rs
@@ -172,10 +172,11 @@ fn build_test_runner_with_config(
     let backend = TestBackend::new(80, 24);
     let config = AppConfig {
         directory: directory.map(|d| d.to_str().unwrap().to_owned()),
-        hidden: false,
+        include_hidden: false,
         advanced_regex,
         search_field_values,
         log_level: LevelFilter::Warn,
+        immediate_search: false,
     };
 
     let (event_sender, event_stream) = TestEventStream::new();


### PR DESCRIPTION
Now that [this PR](https://github.com/thomasschafer/scooter/pull/90) is merged which added CLI args to pre-populate fields, it would be useful to optionally jump straight to searching without showing the fields. This PR adds a flag `--immediate-search` for that purpose, e.g.:

```sh
scooter --search-text "old" --replace-text "new" --immediate-search
```


https://github.com/user-attachments/assets/3ea42ec0-769a-438d-b5bd-3f6fdc9031f9

Resolves https://github.com/thomasschafer/scooter/issues/94