### PR TITLE
Add --editor-command flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ command = "vi %file +%line"
 ```
 If not set explicitly, scooter will attempt to use the editor set by the `$EDITOR` environment variable.
 
+This can be overridden using the `--editor-command` flag, for example: `scooter --editor-command "vi %file +%line"`.
+
 #### `exit`
 
 Whether to exit scooter after running the command defined by `editor_open.command`. Defaults to `false`.

--- a/scooter-core/src/config.rs
+++ b/scooter-core/src/config.rs
@@ -98,6 +98,8 @@ pub struct EditorOpenConfig {
     /// command = "vi %file +%line"
     /// ```
     /// If not set explicitly, scooter will attempt to use the editor set by the `$EDITOR` environment variable.
+    ///
+    /// This can be overridden using the `--editor-command` flag, for example: `scooter --editor-command "vi %file +%line"`.
     pub command: Option<String>,
     /// Whether to exit scooter after running the command defined by `editor_open.command`. Defaults to `false`.
     pub exit: bool,

--- a/scooter/src/app_runner.rs
+++ b/scooter/src/app_runner.rs
@@ -42,6 +42,7 @@ pub struct AppConfig<'a> {
     pub search_field_values: SearchFieldValues<'a>,
     pub app_run_config: AppRunConfig,
     pub stdin_content: Option<String>,
+    pub editor_command_override: Option<String>,
 }
 
 impl Default for AppConfig<'_> {
@@ -52,6 +53,7 @@ impl Default for AppConfig<'_> {
             search_field_values: SearchFieldValues::default(),
             app_run_config: AppRunConfig::default(),
             stdin_content: None,
+            editor_command_override: None,
         }
     }
 }
@@ -121,7 +123,13 @@ impl AppRunner<CrosstermBackend<io::Stdout>, CrosstermEventStream, NoOpSnapshotP
         let backend = CrosstermBackend::new(io::stdout());
         let event_stream = CrosstermEventStream::new();
         let snapshot_provider = NoOpSnapshotProvider;
-        let user_config = config::load_config().context("Failed to read config file")?;
+        let mut user_config = config::load_config().context("Failed to read config file")?;
+
+        // Apply CLI override for editor command if provided
+        if let Some(ref editor_command) = app_config.editor_command_override {
+            user_config.editor_open.command = Some(editor_command.clone());
+        }
+
         Self::new(
             app_config,
             user_config,


### PR DESCRIPTION
Previously, users would have to make a global decision on how to edit files in scooter. However, when using editor commands like `nvim --remote-send`, the editor behavior would break when _not_ being run in a neovim context.

By providing an override flag for this command, we can customize the editor when building the command to run (e.g. from inside the Neovim configuration itself) so that we can use a general editor command in our main config (e.g. `nvim %file +%line`) while still getting the `--remote-send` behavior when launching scooter from a neovim instance.