### PR TITLE
ci(flake): fix warning for missing meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
           version = "dev";
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
+          meta.mainProgram = "scooter";
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
```
nix-repl> pkgs.lib.getExe outputs.packages.x86_64-linux.default

evaluation warning: getExe: Package scooter-dev does not have the meta.mainProgram attribute.
We'll assume that the main program has the same name for now, but this behavior is deprecated,
because it leads to surprising errors when the assumption does not hold.
If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition,
use getExe' to specify the name to the program, such as lib.getExe' foo "bar".

"/nix/store/05kny5sd9ic0ih362fa3wyd5i4jh18sy-scooter-dev/bin/scooter"
```