### PR TITLE
Bump rand from 0.9.2 to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
  "log-mdc",
  "mock_instant",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde-value",
  "serde_json",
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2731,7 +2731,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "polling",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustc-hash",
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary

- update the transitive `rand` lockfile resolution from `0.9.2` to `0.9.3`
- address GHSA-cq8v-f236-94qc reported against `Cargo.lock`