### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- group Cargo minor and patch updates into one weekly Dependabot PR
- add grouped weekly Dependabot updates for GitHub Actions
- cap open Dependabot PRs per ecosystem at 5

## Testing
- ruby -ryaml -e 'YAML.load_file(%q[.github/dependabot.yml]); puts %q[ok]'