### PR TITLE
Add EventChannels::try_recv; fix open-in-editor panic with no results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "scooter-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",

--- a/scooter-core/Cargo.toml
+++ b/scooter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scooter-core"
-version = "0.3.3"
+version = "0.4.0"
 edition.workspace = true
 authors = ["thomasschafer97@gmail.com"]
 license = "MIT"

--- a/scooter-core/src/app.rs
+++ b/scooter-core/src/app.rs
@@ -635,6 +635,12 @@ impl EventChannels {
     pub async fn recv(&mut self) -> Option<Event> {
         self.receiver.recv().await
     }
+
+    /// Non-blocking receive, for callers that pump events from a synchronous
+    /// context (e.g. the Helix plugin) rather than awaiting inside a runtime.
+    pub fn try_recv(&mut self) -> Option<Event> {
+        self.receiver.try_recv().ok()
+    }
 }
 
 impl Default for EventChannels {

--- a/scooter-core/src/app.rs
+++ b/scooter-core/src/app.rs
@@ -1809,9 +1809,10 @@ impl<'a> App {
                     .current_screen
                     .unwrap_search_fields_state_mut();
                 if let Some(ref mut search_in_progress_state) = search_fields_state.search_state {
-                    let selected = search_in_progress_state
-                        .primary_selected_field_mut()
-                        .expect("Expected to find selected field");
+                    let Some(selected) = search_in_progress_state.primary_selected_field_mut()
+                    else {
+                        return EventHandlingResult::None;
+                    };
                     if let Some(ref path) = selected.search_result.path {
                         self.event_channels
                             .sender
@@ -2736,6 +2737,26 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![] as Vec<bool>
         );
+    }
+
+    #[test]
+    fn test_open_in_editor_with_no_results() {
+        let mut app = App::new(
+            InputSource::Directory(std::env::current_dir().unwrap()),
+            &SearchFieldValues::default(),
+            AppRunConfig::default(),
+            Config::default(),
+        )
+        .unwrap();
+        let search_fields_state = app.ui_state.current_screen.unwrap_search_fields_state_mut();
+        search_fields_state.focussed_section = FocussedSection::SearchResults;
+        search_fields_state.search_state = Some(build_test_search_state(0));
+
+        assert!(matches!(
+            app.handle_command_search_results(CommandSearchFocusResults::OpenInEditor),
+            EventHandlingResult::None
+        ));
+        assert!(app.event_channels.try_recv().is_none());
     }
 
     fn success_result() -> SearchResultWithReplacement {

--- a/scooter/Cargo.toml
+++ b/scooter/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0.102"
-scooter-core = { version = "0.3.3", path = "../scooter-core", features = [
+scooter-core = { version = "0.4.0", path = "../scooter-core", features = [
   "term",
 ] }
 clap = { version = "4.6.1", features = ["derive"] }


### PR DESCRIPTION
- Add `EventChannels::try_recv` so callers pumping events from a synchronous context (e.g. the Helix plugin) can receive without awaiting inside a runtime.
- Fix a panic when triggering open-in-editor with no search results selected: return `EventHandlingResult::None` instead of expecting a selected field.
- Bump scooter-core to 0.4.0.