### PR TITLE
Ignore ratatui dependabot updates until upstream cursor-query regression is fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # ratatui-core 0.1.2 made Terminal::clear() query the backend's cursor
+      # position even for Viewport::Fullscreen, which we call on every TUI
+      # startup (Tui::init). That hangs/times out on non-interactive
+      # terminals (our e2e tests, and CI), breaking the "Test" workflow.
+      # Known upstream bug: https://github.com/ratatui/ratatui/issues/2640
+      # Remove this once that's fixed and a new patch release is out.
+      - dependency-name: "ratatui"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
ratatui-core 0.1.2 made `Terminal::clear()` query the backend's cursor position even for `Viewport::Fullscreen`, which scooter hits on every TUI startup (`Tui::init`). That hangs/times out on non-interactive terminals — our e2e test harness, and evidently CI too — which is what broke #429.

This is an open upstream bug: [ratatui/ratatui#2640](https://github.com/ratatui/ratatui/issues/2640). Until it's fixed, dependabot would just keep proposing the same broken `ratatui` bump every week, so this adds an `ignore` entry for it. Remove once upstream ships a fix.

See #429 for the full investigation/bisection.