### PR TITLE
Bump Rust toolchain to 1.97 and fix new clippy lints

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.97"
 components = ["rustfmt", "rust-src", "clippy"]

--- a/scooter-core/src/replace.rs
+++ b/scooter-core/src/replace.rs
@@ -104,8 +104,7 @@ pub fn spawn_replace_included<T: Fn(SearchResultWithReplacement) + Send + Sync +
         let path_groups = group_results(included);
 
         let num_threads = thread::available_parallelism()
-            .map(NonZero::get)
-            .unwrap_or(4)
+            .map_or(4, NonZero::get)
             .min(12);
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(num_threads)
@@ -4080,16 +4079,11 @@ mod tests {
             let reader = BufReader::new(file);
 
             let mut byte_start = 0;
-            let mut current_line = 1;
 
             // Skip to start_line and track byte position
-            for line_result in reader.lines() {
-                if current_line >= start_line {
-                    break;
-                }
+            for line_result in reader.lines().take(start_line.saturating_sub(1)) {
                 let line = line_result.expect("Failed to read line");
                 byte_start += line.len() + 1; // +1 for newline
-                current_line += 1;
             }
 
             // Build expected content from lines

--- a/scooter-core/src/search.rs
+++ b/scooter-core/src/search.rs
@@ -359,8 +359,7 @@ impl FileSearcher {
 
     fn build_walker(&self) -> ignore::WalkParallel {
         let num_threads = thread::available_parallelism()
-            .map(NonZero::get)
-            .unwrap_or(4)
+            .map_or(4, NonZero::get)
             .min(12);
 
         WalkBuilder::new(&self.dir_config.root_dir)

--- a/scooter-core/tests/app.rs
+++ b/scooter-core/tests/app.rs
@@ -31,7 +31,7 @@ use scooter_core::{
     keyboard::{KeyCode as ScooterKeyCode, KeyModifiers as ScooterKeyModifiers},
 };
 
-const EVENT_TIMEOUT: Duration = Duration::from_millis(2_000);
+const EVENT_TIMEOUT: Duration = Duration::from_secs(2);
 const PRESERVED_DEBOUNCE_MAX_WAIT: Duration = Duration::from_millis(200);
 
 #[tokio::test]

--- a/scooter/tests/app_runner.rs
+++ b/scooter/tests/app_runner.rs
@@ -3994,7 +3994,7 @@ test_with_both_regex_modes!(
         send_key(KeyCode::Enter, &event_sender); // Jump to search results
         send_key(KeyCode::Enter, &event_sender); // Try to begin replacement
 
-        let timeout = Duration::from_millis(3000);
+        let timeout = Duration::from_secs(3);
         let result = tokio::time::timeout(timeout, async {
             // State enum to prevent pressing key twice
             #[derive(PartialEq, Eq)]
@@ -4420,7 +4420,7 @@ async fn test_tui_multiline_advanced_regex_lookaround_replacement() -> anyhow::R
 
     send_key(KeyCode::Enter, &event_sender); // Jump to search results
     send_key(KeyCode::Enter, &event_sender);
-    let timeout = Duration::from_millis(3000);
+    let timeout = Duration::from_secs(3);
     let result = tokio::time::timeout(timeout, async {
         #[derive(PartialEq, Eq)]
         enum WaitingFor {

--- a/xtask/src/build_readme.rs
+++ b/xtask/src/build_readme.rs
@@ -183,7 +183,7 @@ fn process_struct(
                     };
 
                     #[allow(clippy::format_push_string)]
-                    docs.push_str(&format!("### `[{toml_path}]` section\n\n",));
+                    docs.push_str(&format!("### `[{toml_path}]` section\n\n"));
 
                     if !field_doc.is_empty() {
                         docs.push_str(&field_doc);
@@ -193,7 +193,7 @@ fn process_struct(
                     process_struct(docs, nested_struct, all_structs, &toml_path);
                 } else {
                     #[allow(clippy::format_push_string)]
-                    docs.push_str(&format!("#### `{field_name}`\n\n",));
+                    docs.push_str(&format!("#### `{field_name}`\n\n"));
                     docs.push_str(&field_doc);
                     docs.push_str("\n\n");
                 }


### PR DESCRIPTION
Bumps the pinned toolchain in `rust-toolchain.toml` from 1.91 to 1.97 (current stable). This unblocks #431, as serial_test 4.0.1 requires rustc >= 1.93.1.

Fixes the lints new to clippy 1.97:
- `map_unwrap_or`: `.map(NonZero::get).unwrap_or(4)` -> `.map_or(4, NonZero::get)`
- `unnecessary_trailing_comma` in `xtask/src/build_readme.rs`
- `duration_suboptimal_units`: `from_millis(2_000)` -> `from_secs(2)` etc. in tests
- `explicit_counter_loop` in a `replace.rs` test helper, rewritten with `.take()`

Verified locally with `cargo fmt --check`, `cargo clippy --workspace --tests -- -D warnings`, `cargo check`, `cargo xtask readme --check` and `cargo test --workspace`.